### PR TITLE
Enhancement: ANTARESBroker uses HTTP API instead of Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,6 @@ Add `tom_antares.antares.AntaresBroker` to the `TOM_ALERT_CLASSES` in your TOM's
         'tom_antares.antares.ANTARESBroker'
     ]
 
-You'll need Antares credentials to use this plugin. You can register for an account [here](https://antares.noao.edu/accounts/register/). Add your Antares credentials to your project
-'s `settings.py`:
-
-    BROKERS = {
-        'anatares': {
-            'api_key': 'YOUR ANTARES API KEY',
-            'api_secret': 'YOUR ANTARES API SECRET'
-        }
-    }
-
 ## Running the tests
 
 In order to run the tests, run the following in your virtualenv:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add `tom_antares.antares.AntaresBroker` to the `TOM_ALERT_CLASSES` in your TOM's
     TOM_ALERT_CLASSES = [
         'tom_alerts.brokers.mars.MARSBroker',
         ...
-        'tom_antares.antares.AntaresBroker'
+        'tom_antares.antares.ANTARESBroker'
     ]
 
 You'll need Antares credentials to use this plugin. You can register for an account [here](https://antares.noao.edu/accounts/register/). Add your Antares credentials to your project

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     setup_requires=['setuptools_scm', 'wheel'],
     install_requires=[
         'tomtoolkit==2.0.1',
-        'antares-client~=1.0.3',
+        'antares-client~=1.0.4',
         'elasticsearch-dsl~=7.3.0'
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     setup_requires=['setuptools_scm', 'wheel'],
     install_requires=[
         'tomtoolkit==2.0.1',
-        'antares-client~=1.0.1',
+        'antares-client~=1.0.3',
         'elasticsearch-dsl~=7.3.0'
     ],
     extras_require={

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -120,8 +120,7 @@ class ANTARESBroker(GenericBroker):
                 'alert_id': alert.alert_id,
                 'mjd': alert.mjd,
                 'properties': alert.properties
-            }
-            for alert in locus.alerts]
+            } for alert in locus.alerts]
         }
 
     def fetch_alerts(self, parameters: dict) -> iter:

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -1,8 +1,7 @@
 import logging
 import requests
 
-from antares_client import StreamingClient
-from antares_client.exceptions import AntaresException
+import antares_client
 from antares_client.search import get_by_ztf_object_id
 from astropy.time import Time, TimezoneInfo
 from crispy_forms.layout import Fieldset, Layout
@@ -21,22 +20,17 @@ ANTARES_API_URL = 'https://api.antares.noirlab.edu'
 ANTARES_TAG_URL = ANTARES_API_URL + '/v1/tags'
 
 
-def get_available_streams(url=ANTARES_TAG_URL):
+def get_available_tags(url: str = ANTARES_TAG_URL):
     response = requests.get(url).json()
-    streams = response.get('data', {})
+    tags = response.get('data', {})
     if response.get('links', {}).get('next'):
-        return streams + get_available_streams(response['links']['next'])
-    return streams
+        return tags + get_available_tags(response['links']['next'])
+    return tags
 
 
-# def get_tag_choices():
-#     tags = get_available_streams()
-#     return [(s['id'], s['id']) for s in tags]
-
-
-def get_stream_choices():
-    streams = get_available_streams()
-    return [(s['id'] + '_staging', s['id']) for s in streams]
+def get_tag_choices():
+    tags = get_available_tags()
+    return [(s['id'], s['id']) for s in tags]
 
 
 # class ConeSearchWidget(forms.widgets.MultiWidget):
@@ -74,7 +68,7 @@ def get_stream_choices():
 
 
 class ANTARESBrokerForm(GenericQueryForm):
-    stream = forms.MultipleChoiceField(choices=get_stream_choices)
+    tag = forms.MultipleChoiceField(choices=get_tag_choices)
     # cone_search = ConeSearchField()
     # api_search_tags = forms.MultipleChoiceField(choices=get_tag_choices)
 
@@ -86,8 +80,8 @@ class ANTARESBrokerForm(GenericQueryForm):
         self.helper.layout = Layout(
             self.common_layout,
             Fieldset(
-                'View Streams',
-                'stream'
+                'View Tags',
+                'tag'
             ),
             # HTML('<hr/>'),
             # Fieldset(
@@ -106,25 +100,10 @@ class ANTARESBroker(GenericBroker):
     name = 'ANTARES'
     form = ANTARESBrokerForm
 
-    def __init__(self, *args, **kwargs):
-        try:
-            antares_creds = settings.BROKERS['antares']
-            self.config = {
-                'api_key': antares_creds['api_key'],
-                'api_secret': antares_creds['api_secret']
-            }
-            if antares_creds.get('group'):  # Group should only be set if it exists, otherwise Antares manages it
-                self.config['group'] = antares_creds['group']
-            if antares_creds.get('ssl_ca_location'):
-                self.config['ssl_ca_location'] = antares_creds['ssl_ca_location']
-
-        except KeyError:
-            raise ImproperlyConfigured('Missing ANTARES API credentials')
-
     @classmethod
     def alert_to_dict(cls, locus):
         """
-        Note: The ANTARES stream returns a Locus object, which in the TOM Toolkit
+        Note: The ANTARES API returns a Locus object, which in the TOM Toolkit
         would otherwise be called an alert.
 
         This method serializes the Locus into a dict so that it can be cached by the view.
@@ -135,28 +114,37 @@ class ANTARESBroker(GenericBroker):
             'dec': locus.dec,
             'properties': locus.properties,
             'tags': locus.tags,
-            'lightcurve': locus.lightcurve.to_json(),
+            # 'lightcurve': locus.lightcurve.to_json(),
             'catalogs': locus.catalogs,
             'alerts': [{
                 'alert_id': alert.alert_id,
                 'mjd': alert.mjd,
                 'properties': alert.properties
-            } for alert in locus.alerts]
+            }
+            for alert in locus.alerts]
         }
 
     def fetch_alerts(self, parameters: dict) -> iter:
-        stream = parameters['stream']
-        client = StreamingClient(stream, **self.config)  # TODO: may need to be mocked in unit tests
-        alert_stream = client.iter(20)  # TODO: needs to be mocked in unit tests
+        tags = parameters['tag']
+        query = {
+            "query": {
+                "bool": {
+                    "filter": {
+                        "terms": {
+                            "tags": tags,
+                        }
+                    }
+                }
+            }
+        }
+        loci = antares_client.search.search(query)
         alerts = []
-        # TODO: Add timeout in case there aren't alerts
         while len(alerts) < 20:
             try:
-                topic, locus = next(alert_stream)  # An alert is a 2-tuple of (tag, Locus)
-            except (AntaresException, marshmallow.exceptions.ValidationError, StopIteration):
+                locus = next(loci)
+            except (marshmallow.exceptions.ValidationError, StopIteration):
                 break
-            alert_as_dict = self.alert_to_dict(locus)
-            alerts.append((topic, alert_as_dict))
+            alerts.append(self.alert_to_dict(locus))
         return iter(alerts)
 
     def fetch_alert(self, id):
@@ -168,7 +156,6 @@ class ANTARESBroker(GenericBroker):
         pass
 
     def to_target(self, alert: dict) -> Target:
-        _, alert = alert
         target = Target.objects.create(
             name=alert['properties']['ztf_object_id'],
             type='SIDEREAL',
@@ -181,7 +168,6 @@ class ANTARESBroker(GenericBroker):
         return target
 
     def to_generic_alert(self, alert):
-        _, alert = alert
         url = f"{ANTARES_BASE_URL}/loci/{alert['locus_id']}"
         timestamp = Time(
             alert['properties'].get('newest_alert_observation_time'), format='mjd', scale='utc'

--- a/tom_antares/tests/tests.py
+++ b/tom_antares/tests/tests.py
@@ -8,7 +8,6 @@ from tom_antares.tests.factories import LocusFactory
 from tom_targets.models import Target, TargetName
 
 
-@override_settings(BROKERS={'antares': {'api_key': '', 'api_secret': ''}})
 class TestANTARESBrokerClass(TestCase):
     """
     NOTE: to run these tests in your venv: python ./tom_antares/tests/run_tests.py
@@ -18,26 +17,24 @@ class TestANTARESBrokerClass(TestCase):
         self.test_target = Target.objects.create(name='ZTF20achooum')
         self.loci = [LocusFactory.create() for i in range(0, 5)]
         self.locus = self.loci[0]  # Get an individual locus for testing
-        self.topic = 'in_m31_staging'
+        self.tag = 'in_m31'
 
     def test_boilerplate(self):
         """make sure the testing infrastructure is working"""
         self.assertTrue(True)
 
-    @mock.patch('tom_antares.antares.StreamingClient')
-    def test_fetch_alerts(self, mock_streaming_client):
+    @mock.patch('tom_antares.antares.antares_client')
+    def test_fetch_alerts(self, mock_client):
         """
         Test the ANTARES-specific fetch_alerts logic.
         """
-        mock_client = mock_streaming_client.return_value
         # NOTE: if .side_effect is going to return a list, it needs a function that returns a list
-        mock_client.iter.side_effect = lambda loci: iter([(self.topic, locus) for locus in self.loci])
-
+        mock_client.search.search.side_effect = lambda loci: iter(self.loci)
         expected_alert = ANTARESBroker.alert_to_dict(self.locus)
-        alerts = ANTARESBroker().fetch_alerts({'stream': [self.topic]})
+        alerts = ANTARESBroker().fetch_alerts({'tag': [self.tag]})
 
         # TODO: compare iterator length with len(self.loci)
-        self.assertEqual(next(alerts), (self.topic, expected_alert))
+        self.assertEqual(next(alerts), expected_alert)
 
     def test_to_target_with_horizons_targetname(self):
         """
@@ -50,14 +47,14 @@ class TestANTARESBrokerClass(TestCase):
         and one for the horizons_targetname.
         """
         self.locus.properties['horizons_targetname'] = 'test targetname'
-        alert = (self.topic, ANTARESBroker.alert_to_dict(self.locus))
+        alert = ANTARESBroker.alert_to_dict(self.locus)
         _ = ANTARESBroker().to_target(alert)
 
         self.assertEqual(TargetName.objects.all().count(), 2)
 
     def test_to_generic_alert(self):
         self.locus.properties['newest_alert_observation_time'] = 59134  # 10/12/2020
-        generic_alert = ANTARESBroker().to_generic_alert((self.topic, ANTARESBroker.alert_to_dict(self.locus)))
+        generic_alert = ANTARESBroker().to_generic_alert(ANTARESBroker.alert_to_dict(self.locus))
 
         # NOTE: The string is hardcoded as a sanity check to ensure that the string is reviewed if it changes
         self.assertEqual(generic_alert.url, f'https://antares.noirlab.edu/loci/{self.locus.locus_id}')


### PR DESCRIPTION
Hi folks,

We got a report from someone this morning that was having some issues using ANTARES with the TOMToolkit. Interfacing with Kafka introduces a layer of complexity into the TOMToolkit/ANTARES plugin that I think there isn't a compelling reason to support now that we have a robust HTTP API. In addition to providing a path forwards for more supporting more complex queries in the TOM, the HTTP API also eliminates the requirement for API keys to fetch data from ANTARES.

This PR:
- Replaces the Kafka streaming functionality with HTTP queries against our API.
- Updates the README to reflect these changes.
- Updates the patch version of the `antares-client` dependency (some bug fixes that will be necessary in a couple of weeks time).
- Updates the test suite to mock out the test for `fetch_alerts` against the HTTP API.
- Fixes a typo in the README and closes #6.

I'd like to get some input from you all about how this looks--there were a couple of things in terms of data structures/types that I was iffy about. Our API also supports fetching sparse responses which could make load times snappier--I wasn't sure what data returned from `alert_to_dict` was required, for example.

I'm also curious if you could speak to what pagination strategy we should be supporting with queries (if any)? I matched what was happening before this patch, returning the first 20 results from the query.

Looking forward to working with you all on this :smile: Happy new year!
