### PR TITLE
added parameter for max_alerts

### DIFF
--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -135,7 +135,7 @@ class ANTARESBrokerForm(GenericQueryForm):
         label='Maximum number of alerts to fetch',
         widget=forms.TextInput(attrs={'placeholder': 'Max Alerts'}),
         min_value=0.0,
-        initial=50
+        initial=20
     )
 
     # cone_search = ConeSearchField()
@@ -329,7 +329,7 @@ class ANTARESBroker(GenericBroker):
         mag_max = parameters.get('mag__max')
         elsquery = parameters.get('esquery')
         ztfid = parameters.get('ztfid')
-        max_alerts = parameters.get('max_alerts')
+        max_alerts = parameters.get('max_alerts', 20)
         if ztfid:
             query = {
                 "query": {

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -132,10 +132,10 @@ class ANTARESBrokerForm(GenericQueryForm):
     )
     max_alerts = forms.FloatField(
         required=False,
-        label = 'Maximum number of alerts to fetch',
+        label='Maximum number of alerts to fetch',
         widget=forms.TextInput(attrs={'placeholder': 'Max Alerts'}),
         min_value=0.0,
-        initial = 50
+        initial=50
     )
 
     # cone_search = ConeSearchField()

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -130,6 +130,13 @@ class ANTARESBrokerForm(GenericQueryForm):
         label='Elastic Search query in JSON format',
         widget=forms.TextInput(attrs={'placeholder': '{"query":{}}'}),
     )
+    max_alerts = forms.FloatField(
+        required=False,
+        label = 'Maximum number of alerts to fetch',
+        widget=forms.TextInput(attrs={'placeholder': 'Max Alerts'}),
+        min_value=0.0,
+        initial = 50
+    )
 
     # cone_search = ConeSearchField()
     # api_search_tags = forms.MultipleChoiceField(choices=get_tag_choices)
@@ -220,6 +227,10 @@ class ANTARESBrokerForm(GenericQueryForm):
             Fieldset(
                 'View Tags',
                 'tag'
+            ),
+            Fieldset(
+                'Max Alerts',
+                'max_alerts'
             ),
             HTML('<hr/>'),
             HTML('<p style="color:blue;font-size:30px">Advanced query</p>'),
@@ -318,6 +329,7 @@ class ANTARESBroker(GenericBroker):
         mag_max = parameters.get('mag__max')
         elsquery = parameters.get('esquery')
         ztfid = parameters.get('ztfid')
+        max_alerts = parameters.get('max_alerts')
         if ztfid:
             query = {
                 "query": {
@@ -384,7 +396,7 @@ class ANTARESBroker(GenericBroker):
 #        if ztfid:
 #            loci = get_by_ztf_object_id(ztfid)
         alerts = []
-        while len(alerts) < 20:
+        while len(alerts) < max_alerts:
             try:
                 locus = next(loci)
             except (marshmallow.exceptions.ValidationError, StopIteration):

--- a/tom_antares/tests/tests.py
+++ b/tom_antares/tests/tests.py
@@ -39,7 +39,6 @@ class TestANTARESBrokerClass(TestCase):
         alerts = ANTARESBroker().fetch_alerts({'max_alerts': 4})
         self.assertEqual(len(list(alerts)), 4)
 
-
     def test_to_target_with_horizons_targetname(self):
         """
         Test that the expected names are created.

--- a/tom_antares/tests/tests.py
+++ b/tom_antares/tests/tests.py
@@ -31,10 +31,10 @@ class TestANTARESBrokerClass(TestCase):
 
         # TODO: compare iterator length with len(self.loci)
         self.assertEqual(next(alerts), expected_alert)
-    
+
     @mock.patch('tom_antares.antares.antares_client')
     def test_fetch_alerts_max_alerts(self, mock_client):
-        '''Tests that the max_alerts parameter actually affects the length of the alert stream'''
+        """Tests that the max_alerts parameter actually affects the length of the alert stream"""
         mock_client.search.search.side_effect = lambda loci: iter(self.loci)
         alerts = ANTARESBroker().fetch_alerts({'max_alerts': 4})
         self.assertEqual(len(list(alerts)), 4)

--- a/tom_antares/tests/tests.py
+++ b/tom_antares/tests/tests.py
@@ -27,10 +27,18 @@ class TestANTARESBrokerClass(TestCase):
         # NOTE: if .side_effect is going to return a list, it needs a function that returns a list
         mock_client.search.search.side_effect = lambda loci: iter(self.loci)
         expected_alert = ANTARESBroker.alert_to_dict(self.locus)
-        alerts = ANTARESBroker().fetch_alerts({'tag': [self.tag]})
+        alerts = ANTARESBroker().fetch_alerts({'tag': [self.tag], 'max_alerts': 3})
 
         # TODO: compare iterator length with len(self.loci)
         self.assertEqual(next(alerts), expected_alert)
+    
+    @mock.patch('tom_antares.antares.antares_client')
+    def test_fetch_alerts_max_alerts(self, mock_client):
+        '''Tests that the max_alerts parameter actually affects the length of the alert stream'''
+        mock_client.search.search.side_effect = lambda loci: iter(self.loci)
+        alerts = ANTARESBroker().fetch_alerts({'max_alerts': 4})
+        self.assertEqual(len(list(alerts)), 4)
+
 
     def test_to_target_with_horizons_targetname(self):
         """


### PR DESCRIPTION
I added a parameter to the fetch_alerts function that allows a user to change the number of alerts returned. Before, the maximum number of alerts was hard coded as 20, but changing that to be part of the query provides users and developers more flexibility to query for longer more general sets of alerts. I reflected this change in the broker query and testing suite as well.  