### PR TITLE
Expanded query options and updated form layout

### DIFF
--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -148,10 +148,10 @@ class ANTARESBrokerForm(GenericQueryForm):
             '''
             ),
             HTML('<hr/>'),
-            HTML('<p style="color:blue;font-size:30px">Query by object name</p>'),
+            HTML('<h3>Query by object name</h3>'),
             Fieldset('ZTF object ID', 'ztfid'),
             HTML('<hr/>'),
-            HTML('<p style="color:blue;font-size:30px">Simple query form</p>'),
+            HTML('<h3>Simple query form</h3>'),
             Fieldset(
                 'Alert timing',
                 Div(
@@ -206,7 +206,7 @@ class ANTARESBrokerForm(GenericQueryForm):
             Fieldset('View Tags', 'tag'),
             Fieldset('Max Alerts', 'max_alerts'),
             HTML('<hr/>'),
-            HTML('<p style="color:blue;font-size:30px">Advanced query</p>'),
+            HTML('<h3>Advanced query</h3>'),
             Fieldset('', 'esquery'),
             HTML(
                 '''

--- a/tom_antares/tests/tests.py
+++ b/tom_antares/tests/tests.py
@@ -15,6 +15,7 @@ class TestANTARESBrokerClass(TestCase):
         self.test_target = Target.objects.create(name='ZTF20achooum')
         self.loci = [LocusFactory.create() for i in range(0, 5)]
         self.locus = self.loci[0]  # Get an individual locus for testing
+        self.locus_id = 'ANT2025v5k9wxb6vzbe'
         self.tag = 'in_m31'
 
     def test_boilerplate(self):
@@ -62,3 +63,10 @@ class TestANTARESBrokerClass(TestCase):
         # NOTE: The string is hardcoded as a sanity check to ensure that the string is reviewed if it changes
         self.assertEqual(generic_alert.url, f'https://antares.noirlab.edu/loci/{self.locus.locus_id}')
         self.assertEqual(generic_alert.timestamp, datetime(2020, 10, 12, tzinfo=timezone.utc))
+
+    @mock.patch('tom_antares.antares.antares_client')
+    def test_fetch_alerts_by_locus_id(self, mock_client):
+        """Test that a query by locus identifier parses the alert properly"""
+        mock_client.search.search.side_effect = lambda loci: iter(self.loci)
+        alerts = ANTARESBroker().fetch_alerts({'antid': 'ANT2025v5k9wxb6vzbe'})
+        self.assertEqual(len(list(alerts)), 1)


### PR DESCRIPTION
I've removed the hardcoded CSS styling of some sub-headers in the ANTARES query form so that user-customized CSS can more effectively override styling without customizing the template.  

I've also added support for two queries that are likely to be generally useful:
* Query by ANTARES locus ID (rather than just by ZTF ID) - this is more general and not tied to one survey.  This is likely necessary for Rubin alerts in the near future,
* Added a checkbox so users can more easily request alerts that have come in within the last 24hrs.

