### PR TITLE
41 antares client incompatible with python310 without librdkafka

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9, 3.10]
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10]
+        python-version: ['3.9', '3.10']
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering :: Astronomy',
         'Topic :: Scientific/Engineering :: Physics'
     ],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     setup_requires=['setuptools_scm', 'wheel'],
     install_requires=[
         'tomtoolkit>=2.12,<3.0',
-        'antares-client>=1.9,<2.0',
+        'antares-client>=1.10,<2.0',
         'elasticsearch-dsl>=7.3,<7.5'
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     setup_requires=['setuptools_scm', 'wheel'],
     install_requires=[
         'tomtoolkit>=2.12,<3.0',
-        'antares-client>=1.4,<2.0',
+        'antares-client>=1.9,<2.0',
         'elasticsearch-dsl>=7.3,<7.5'
     ],
     extras_require={


### PR DESCRIPTION
Fixes #41 by dropping python 3.8 support so antares-client can be updated to a version which makes kafka streaming optional.