### PR TITLE
Cone search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,5 @@ pattern = "(?x)^[v]?((?P<epoch>\\d+)!)?(?P<base>\\d+(\\.\\d+)*)([-._]?((?P<stage
 [tool.poetry-dynamic-versioning.substitution]
 
 [build-system]
-requires = ["poetry-core >=2.0.0, <3.0.0"]
+requires = ["poetry-core >=2.0.0, <3.0.0", "poetry-dynamic-versioning >=0.22.0"]
 build-backend = "poetry_dynamic_versioning.backend"

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -748,7 +748,7 @@ class AntaresDataService(DataService):
                 datum_details['limit'] = datum['ant_maglim']
             datum_details['filter'] = datum['ant_passband']
 
-            reduced_datum, __ = ReducedDatum.objects.get_or_create(
+            reduced_datum = ReducedDatum(
                 target=target,
                 timestamp=Time(datum['time'], format='iso', scale='utc').to_datetime(TimezoneInfo()),
                 data_type=data_type,
@@ -756,4 +756,5 @@ class AntaresDataService(DataService):
                 value=datum_details
             )
             reduced_datums.append(reduced_datum)
+        ReducedDatum.objects.bulk_create(reduced_datums, ignore_conflicts=True)
         return reduced_datums

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -94,12 +94,14 @@ class ANTARESBrokerForm(GenericQueryForm):
         label='RA',
         widget=forms.TextInput(attrs={'placeholder': 'RA (Degrees)'}),
         min_value=0.0,
+        max_value=360.,
     )
     dec = forms.FloatField(
         required=False,
         label='Dec',
         widget=forms.TextInput(attrs={'placeholder': 'Dec (Degrees)'}),
-        min_value=0.0,
+        min_value=-90.,
+        max_value=90.,
     )
     sr = forms.FloatField(
         required=False,

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -17,6 +17,7 @@ from tom_targets.models import Target, TargetName
 from tom_dataproducts.models import ReducedDatum
 
 from tom_antares.forms import AntaresForm
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -730,9 +731,15 @@ class AntaresDataService(DataService):
         reduced_datums = []
         for datum in data:
             datum_details = dict(datum)
-            datum_details['magnitude'] = datum['ant_mag']
-            datum_details['error'] = datum['ant_magerr']
-            datum_details['limit'] = datum['ant_maglim']
+            if (not (isinstance(datum['ant_mag'], float) and np.isfinite(datum['ant_mag']))
+                    and not (isinstance(datum['ant_maglim'], float) and np.isfinite(datum['ant_maglim']))):
+                continue
+            if isinstance(datum['ant_mag'], float) and np.isfinite(datum['ant_mag']):
+                datum_details['magnitude'] = datum['ant_mag']
+            if isinstance(datum['ant_magerr'], float) and np.isfinite(datum['ant_magerr']):
+                datum_details['error'] = datum['ant_magerr']
+            if isinstance(datum['ant_maglim'], float) and np.isfinite(datum['ant_maglim']):
+                datum_details['limit'] = datum['ant_maglim']
             datum_details['filter'] = datum['ant_passband']
 
             reduced_datum, __ = ReducedDatum.objects.get_or_create(

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -750,7 +750,7 @@ class AntaresDataService(DataService):
 
             reduced_datum, __ = ReducedDatum.objects.get_or_create(
                 target=target,
-                timestamp=Time(datum['time'], format='iso', scale='utc').datetime,
+                timestamp=Time(datum['time'], format='iso', scale='utc').to_datetime(TimezoneInfo()),
                 data_type=data_type,
                 source_name=f"{self.surveys[datum['properties']['ant_survey']]} (ANTARES)",
                 value=datum_details

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -523,6 +523,12 @@ class AntaresDataService(DataService):
     info_url = 'https://nsf-noirlab.gitlab.io/csdc/antares/client/tutorial/searching.html'
     app_version = __version__
     app_link = 'https://github.com/TOMToolkit/tom_antares'
+    surveys = {
+        1: 'ZTF',
+        2: 'ZTF',
+        3: 'DECAT',
+        4: 'LSST',
+    }  # see antares_devkit.models.SURVEYS
 
     @classmethod
     def get_form_class(cls):
@@ -746,7 +752,7 @@ class AntaresDataService(DataService):
                 target=target,
                 timestamp=Time(datum['time'], format='iso', scale='utc').datetime,
                 data_type=data_type,
-                source_name='Antares',
+                source_name=f"{self.surveys[datum['properties']['ant_survey']]} (ANTARES)",
                 value=datum_details
             )
             reduced_datums.append(reduced_datum)

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -632,13 +632,13 @@ class AntaresDataService(DataService):
         for name in target.names:
             if name.startswith('ZTF'):
                 parameters = {'ztfid': name}
-                return self.build_query_parameters(parameters)
+                break
             elif target.name.startswith('ANT'):
                 parameters = {'antid': name}
-                return self.build_query_parameters(parameters)
-            else:
-                continue
-        raise QueryServiceError(f"{self.name} Dataservice doesn't recognize {target.name} as a searchable target name.")
+                break
+        else:
+            parameters = {'ra': target.ra, 'dec': target.dec, 'sr': 1. / 3600.}  # hardcoding 1 arcsec for now
+        return self.build_query_parameters(parameters)
 
     def query_service(self, data, **kwargs):
         try:


### PR DESCRIPTION
Right now, you can only update data from ANTARES if the target already has an ANT or ZTF name. This adds a cone search as a fallback if neither of those names is available. It also adds a few other bug fixes:
* require `poetry-dynamic-versioning`
* fix RA/dec limits
* avoid `None`/`nan` in magnitudes and limits