### PR TITLE
separate serialize_locus into its own method

### DIFF
--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -664,6 +664,17 @@ class AntaresDataService(DataService):
         except Exception as e:
             raise QueryServiceError(e)
 
+    def serialize_locus(self, locus):
+        result = {'name': locus.locus_id,
+                  'ra': locus.ra,
+                  'dec': locus.dec,
+                  'mag': locus.properties.get('newest_alert_magnitude', ''),
+                  'tags': locus.tags,
+                  'aliases': self.query_aliases(data, locus=locus),
+                  'reduced_datums': {'photometry': self.query_photometry(data, locus)}
+                  }
+        return result
+
     def query_targets(self, data):
         loci = self.query_service(data)
         targets = []
@@ -671,14 +682,7 @@ class AntaresDataService(DataService):
             if isinstance(loci, antares_client.models.Locus):
                 loci = [loci]
             for i, locus in enumerate(loci):
-                result = {'name': locus.locus_id,
-                          'ra': locus.ra,
-                          'dec': locus.dec,
-                          'mag': locus.properties.get('newest_alert_magnitude', ''),
-                          'tags': locus.tags,
-                          'aliases': self.query_aliases(data, locus=locus),
-                          'reduced_datums': {'photometry': self.query_photometry(data, locus)}
-                          }
+                result = self.serialize_locus(locus)
                 targets.append(result)
                 if i+1 == data.get('max_objects', 20):
                     break

--- a/tom_antares/antares.py
+++ b/tom_antares/antares.py
@@ -515,6 +515,19 @@ class ANTARESBroker(GenericBroker):
         )
 
 
+def nan2str(obj):
+    """
+    Remove any NaN or Infinity from an object before JSON encoding
+    """
+    if isinstance(obj, dict):
+        return {k: nan2str(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [nan2str(v) for v in obj]
+    elif isinstance(obj, float) and not np.isfinite(obj):
+        return str(obj)
+    return obj
+
+
 class AntaresDataService(DataService):
     """
         The ``AntaresDataService``
@@ -673,7 +686,7 @@ class AntaresDataService(DataService):
                   'aliases': self.query_aliases(data, locus=locus),
                   'reduced_datums': {'photometry': self.query_photometry(data, locus)}
                   }
-        return result
+        return nan2str(result)
 
     def query_targets(self, data):
         loci = self.query_service(data)


### PR DESCRIPTION
This refactors `AntaresDataService` to create a separate `serialize_locus` method. This is useful when we are streaming Kafka alerts from Antares. We need to store the alerts as JSON so that we can run asynchronous processing on them, and this is essentially the same function you use for caching alerts.

For reference, this is basically the same as the former `AntaresBroker.alert_to_dict` method.